### PR TITLE
Added provided JWT test case

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,10 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinx_json_version")
 
     testImplementation("io.ktor:ktor-server-tests:$ktor_version")
+    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    testImplementation(kotlin("test"))
 
     val junitVersion = "5.10.1"
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/src/test/kotlin/org/openmbee/flexo/mms/ApplicationTest.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ApplicationTest.kt
@@ -1,0 +1,40 @@
+package org.openmbee.flexo.mms
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.config.*
+import io.ktor.server.testing.*
+import java.security.KeyPairGenerator
+import java.util.*
+import org.junit.jupiter.api.Test
+import org.openmbee.flexo.mms.auth.module
+import kotlin.test.assertEquals
+
+class ApplicationTest {
+    @Test
+    fun userIsGreetedProperly() = testApplication {
+        val generator = KeyPairGenerator.getInstance("RSA")
+        generator.initialize(2048)
+        val keyPair = generator.genKeyPair()
+
+
+        environment {
+            config = MapApplicationConfig(
+                "jwt.privateKey" to Base64.getEncoder().encodeToString(keyPair.private.encoded),
+                "jwt.issuer" to "issuer.test",
+                "jwt.audience" to "audience",
+                "jwt.realm" to "realm",
+                "jwt.domain" to "domain",
+                "jwt.secret" to "123",
+            )
+        }
+
+        application {
+            module()
+        }
+
+        val greetings = client.get("/").bodyAsText()
+        assertEquals("Hello World!", greetings)
+    }
+}


### PR DESCRIPTION
## Update
In an effort in increase our code coverage I've added a unit test for when a JWT is already provided. With the current implementation there are no external authentication providers for the JWT. What I've done is recreated the environment with test data for a `issuer`, `audience`, `secret` and `relm`. Since the application reads these settings as environment variables, I went ahead and defined them in the test. Since we know the test secret, it's later used to generate a JWT.  

### Relevant Documentation
🔗 [Ktor testing documentation](https://ktor.io/docs/testing.html)